### PR TITLE
Add Promise as a global

### DIFF
--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -9,6 +9,9 @@ parserOptions:
     # Allow ES6.
     ecmaVersion: 6
 
+globals:
+    Promise: true
+
 extends:
     "eslint:recommended"
 


### PR DESCRIPTION
We use Promise in ES5 and ES6. We shim it in the frontend, but the babel converter wants it to be referred to as `Promise`, not `global.Promise`, so we use this rule in both cases.