### PR TITLE
Add linting for Mocha

### DIFF
--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -5,6 +5,9 @@ env:
     node: true
     mocha: true
 
+plugins:
+    - 'mocha'
+
 parserOptions:
     # Allow ES6.
     ecmaVersion: 6
@@ -150,3 +153,8 @@ rules:
     # Well, we should start using loggers more consistently so we can turn
     # this on.
     no-console: "off"
+
+    # Mocha.
+    "mocha/handle-done-callback": "error"
+    "mocha/no-global-tests": "error"
+    "mocha/no-mocha-global-arrows": "error"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "eslint": ">=2.13.0"
   },
   "dependencies": {
+    "eslint-plugin-mocha": "git+https://github.com/bodylabs/eslint-plugin-mocha.git#no_mocha_global_arrows",
     "js-yaml": ">=3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "eslint": ">=2.13.0"
   },
   "dependencies": {
-    "eslint-plugin-mocha": "git+https://github.com/bodylabs/eslint-plugin-mocha.git#no_mocha_global_arrows",
+    "eslint-plugin-mocha": "git+https://github.com/bodylabs/eslint-plugin-mocha.git#b81be5be171485a61998146ebf151f5140a412fb",
     "js-yaml": ">=3"
   }
 }


### PR DESCRIPTION
Hoping to get `no-mocha-global-arrows` pulled in upstream: lo1tuma/eslint-plugin-mocha#78.

Meanwhile, seems like we could pull this in here.

The main value is linting arrows in mocha, which should reduce the need to comment on it in PR comments, and also make conversion faster, since you'll see the problems right away.

Other two options are nice-to-haves:

- missing `done` callbacks
- we don't tend to use `it` outside `describe`, so enforce that.