### PR TITLE
Enforce single quotes for string literals

### DIFF
--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -150,3 +150,6 @@ rules:
     # Well, we should start using loggers more consistently so we can turn
     # this on.
     no-console: "off"
+
+    # Consistency.
+    quotes: ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }]


### PR DESCRIPTION
`avoidEscape` means we can use double quotes to avoid quoting single quotes inside, and `allowTemplateLiterals` allows template literals with nothing interpolated inside them.

The quote style and both exceptions are consistent with what we generally do.

I tested on `creel-server`, `guts-orchestrator`, and `blue-frontend`, and it only yielded real warnings we'd want to fix. (Lots in `blue-frontend`!)