### PR TITLE
Lint useless constructors and renames in ES6

### DIFF
--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -144,6 +144,10 @@ rules:
     # ES6 arrow functions.
     arrow-spacing: "error"
 
+    # ES6 object literals.
+    no-useless-constructor: "error"
+    no-useless-rename: "error"
+
     # Disable a couple of the recommended checks:
 
     # Allow unused parameters. In callbacks, removing them seems to obscure

--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -140,13 +140,11 @@ rules:
     # ES6.
     prefer-const: "warn"
     require-yield: "error"
+    no-useless-constructor: "error"
+    no-useless-rename: "error"
 
     # ES6 arrow functions.
     arrow-spacing: "error"
-
-    # ES6 object literals.
-    no-useless-constructor: "error"
-    no-useless-rename: "error"
 
     # Disable a couple of the recommended checks:
 


### PR DESCRIPTION
`no-useless-rename` is for ES6 cleanup and consistency, something I see a lot of and it hard to catch manually.

`no-useless-constructor` is something I see occasionally, and makes sense for removing useless code.