### PR TITLE
Use strict mode everywhere

### DIFF
--- a/eslint/common-es6.yml
+++ b/eslint/common-es6.yml
@@ -2,8 +2,6 @@ extends:
     "./eslint/common.yml"
 
 rules:
-    strict: ["error", "global"]
-
     no-var: "error"
     no-const-assign: "error"
 

--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -19,6 +19,9 @@ extends:
     "eslint:recommended"
 
 rules:
+    # Strict mode.
+    strict: ["error", "global"]
+
     # Four-space indent.
     indent: ["error", 4, { "SwitchCase": 1 }]
     no-mixed-spaces-and-tabs: "error"


### PR DESCRIPTION
`common-es6` is for projects which are 100% ES6. This rule is a also good idea on our projects which are in ES5, or are still being converted over.