### PR TITLE
Enforce the line break position of the ternary else

### DIFF
--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -81,7 +81,7 @@ rules:
     # foo.bar = 123;
     comma-style: ["error"]
     comma-dangle: ["error", "always-multiline"]
-    operator-linebreak: ["error", "after"]
+    operator-linebreak: ["error", "after", { "overrides": { "?": "before", ":": "before" } } ]
     array-bracket-spacing: ["error", "never"]
     object-curly-spacing: ["error", "always"]
     key-spacing: "error"

--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -81,7 +81,7 @@ rules:
     # foo.bar = 123;
     comma-style: ["error"]
     comma-dangle: ["error", "always-multiline"]
-    operator-linebreak: ["error", "after", { "overrides": { ":": "ignore" } } ]
+    operator-linebreak: ["error", "after"]
     array-bracket-spacing: ["error", "never"]
     object-curly-spacing: ["error", "always"]
     key-spacing: "error"


### PR DESCRIPTION
I don't have a preference about whether the linebreak is before or after the `:`, but think we should pick one.

_After_ seems more consistent with, well, everything else, but I think @maxdumas had a preference to go the other way, so I'm down to hear his argument.