### PR TITLE
Don't create a function inside a loop

### DIFF
--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -110,6 +110,9 @@ rules:
     # Automatic semicolon insertion is pretty bad.
     semi: "error"
 
+    # Creating a function in a loop is a big gotcha.
+    no-loop-func: "error"
+
     # Crockford, seems sensible.
     no-empty: "error"
 


### PR DESCRIPTION
This is to avoid writing code like this, which doesn't work as you expect.

```js
var printers = [];

for (var i = 0; i < 5; ++i) {
    var printer = function () {
        console.log(i);
    }

    printers.push(printer);
}

printers.forEach(function (printer) {
    printer();
});
```

The rule comes from Crockford. We used to have it turned on, but seem to have lost it somewhere along the way.

The one time I ignored this rule, it was a bug.