### PR TITLE
Add no-process-env

### DIFF
--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -22,6 +22,9 @@ rules:
     # Strict mode.
     strict: ["error", "global"]
 
+    # Don't read from process.env. Disable in config and tests when needed.
+    no-process-env: "error"
+
     # Four-space indent.
     indent: ["error", 4, { "SwitchCase": 1 }]
     no-mixed-spaces-and-tabs: "error"


### PR DESCRIPTION
EDIT: link to rule: http://eslint.org/docs/rules/no-process-env

Per code invariant 3, components don't read from `process.env` https://github.com/bodylabs/engineering-culture/blob/master/architecture/javascript/00-invariants.md#code-invariants

Explicitly disable in config, tests, etc where needed with
`/* eslint-disable no-process-env */`
e.g. in a place like https://github.com/bodylabs/guts-message-router/blob/master/src/sqs-message-router.integration.js#L9