### PR TITLE
Add max-len

### DIFF
--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -27,7 +27,11 @@ rules:
     no-mixed-spaces-and-tabs: "error"
     no-trailing-spaces: "error"
 
-    # Newlint at end of file.
+    # Enforce reasonable line lengths and short comments.
+    # Note that trailing comments are treated as code.
+    max-len: ["error", { "code": 120, "comments": 80, "ignoreUrls": true }]
+
+    # Newline at end of file.
     eol-last: "error"
 
     # Line comments start with a space <-- like this one does.

--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -28,7 +28,7 @@ rules:
     no-trailing-spaces: "error"
 
     # Enforce reasonable line lengths and short comments.
-    # Note that trailing comments are treated as code.
+    # Note that trailing comments can go to 120.
     max-len: ["error", { "code": 120, "comments": 80, "ignoreUrls": true }]
 
     # Newline at end of file.


### PR DESCRIPTION
Rule link: http://eslint.org/docs/rules/max-len

Line lengths have occasionally been pointed out to me in code reviews, especially newlines for comments at 80 chars. Code to 80 is too short IMO; I like 120 (as a hard limit! not that we should be trying to fill 120 every time).

Note that the comment restriction could be a bit annoying when representing structured data in long comments, e.g. https://github.com/bodylabs/guts-message-router/blob/master/src/message-router-expectations.js or https://github.com/bodylabs/guts-orchestrator/blob/master/orchestrator/deduplicator.js#L23 ...but maybe we should just add some line breaks to those.

Also note that eslint treats trailing comments, e.g. 
```
const foo = 5; // the reason five is special here is because....
```
as code, so the 120 limit applies, which IMO is correct.