### PR TITLE
80 arrow body style

### DIFF
--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -164,9 +164,6 @@ rules:
     # Spaces before and after arrow, e.g. a => a
     arrow-spacing: "error"
 
-    # Don't write `a => 1 ? 2 : 3` (could be confused with `a <= 1 ? 2 : 3;`)
-    no-confusing-arrow: "error"
-
     # Disable a couple of the recommended checks:
 
     # Allow unused parameters. In callbacks, removing them seems to obscure

--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -157,7 +157,7 @@ rules:
     arrow-parens: ["error", "as-needed"]
 
     # No usless return keyword for one-line arrow functions
-    # Write i => i + 1 instead of i => { return i + 1 }, and for objects too,
+    # Write i => i + 1 instead of i => { return i + 1; }, and for objects too,
     # write i => ({ foo: i }) instead of i => { return { foo: i }; }
     arrow-body-style: ["error", "as-needed"]
 

--- a/eslint/common.yml
+++ b/eslint/common.yml
@@ -156,7 +156,12 @@ rules:
     # (a, b, c) => a;
     arrow-parens: ["error", "as-needed"]
 
-    # ES6 arrow functions.
+    # No usless return keyword for one-line arrow functions
+    # Write i => i + 1 instead of i => { return i + 1 }, and for objects too,
+    # write i => ({ foo: i }) instead of i => { return { foo: i }; }
+    arrow-body-style: ["error", "as-needed"]
+
+    # Spaces before and after arrow, e.g. a => a
     arrow-spacing: "error"
 
     # Don't write `a => 1 ? 2 : 3` (could be confused with `a <= 1 ? 2 : 3;`)


### PR DESCRIPTION
Rule link: http://eslint.org/docs/rules/arrow-body-style

With `as-needed` option, we disallow useless `return` in one-line functions. The documentation for `as-needed` isn't as explicit as it could be, so here is some example code:

```js
'use strict';

/* eslint-disable no-unused-expressions */

let i = 0;
const increment = () => ++i;



// PASSING EXAMPLES:

// one-line function with implicit return
() => increment();

// brackets suppress return value
() => {
    increment();
};

// multi-line function with return
() => {
    increment();
    return increment();
};

// slightly awkward that you have to wrap object literals in parens
() => ({});

// this is the no-op function, and is distinct from the above
() => {};



// FAILING EXAMPLES:

// useless brackets and return
() => {
    return increment();
};

// not quite as bad when returning object literal, but I still dislike it
() => {
    return {};
};
```